### PR TITLE
bugfix : correction de l'affichage de la nav barre

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -221,6 +221,8 @@ footer p {
     
     .nav-links {
         gap: 1rem;
+        flex-wrap: wrap !important;
+        justify-content: center !important;
     }
     
     main {


### PR DESCRIPTION
J'ai ajouté un attribut flex-wrap et justify-content pour la classe nav-links.
L'affichage de tout les liens de la nav barre reste donc inclus dans la taille de l'ecran du telephone.

#16 